### PR TITLE
[Hotfix] Missing Job/Gang found

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -116,6 +116,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
         InstalledApps = {},
     }
     -- Job
+    if not QBCore.Shared.Jobs[PlayerData.job.name] then PlayerData.job = nil end
     PlayerData.job = PlayerData.job or {}
     PlayerData.job.name = PlayerData.job.name or 'unemployed'
     PlayerData.job.label = PlayerData.job.label or 'Civilian'
@@ -128,6 +129,7 @@ function QBCore.Player.CheckPlayerData(source, PlayerData)
     PlayerData.job.grade.name = PlayerData.job.grade.name or 'Freelancer'
     PlayerData.job.grade.level = PlayerData.job.grade.level or 0
     -- Gang
+    if not QBCore.Shared.Gangs[PlayerData.gang.name] then PlayerData.gang = nil end
     PlayerData.gang = PlayerData.gang or {}
     PlayerData.gang.name = PlayerData.gang.name or 'none'
     PlayerData.gang.label = PlayerData.gang.label or 'No Gang Affiliaton'


### PR DESCRIPTION
- If a job or gang isnt found in shared, it will error out and character can not spawn